### PR TITLE
Potential fix for code scanning alert no. 6: Disabled Spring CSRF protection

### DIFF
--- a/backend/src/main/java/com/lakucha/config/SecurityConfig.java
+++ b/backend/src/main/java/com/lakucha/config/SecurityConfig.java
@@ -87,7 +87,7 @@ public class SecurityConfig {
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http
-                .csrf(csrf -> csrf.disable())
+                .csrf(csrf -> {})
                 .cors(cors -> cors.configurationSource(corsConfigurationSource()))
                 .sessionManagement(sm -> sm.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .exceptionHandling(eh -> eh


### PR DESCRIPTION
Potential fix for [https://github.com/Ngaremaina/Lakucha-Dishes/security/code-scanning/6](https://github.com/Ngaremaina/Lakucha-Dishes/security/code-scanning/6)

The best fix is to **remove global CSRF disabling** and keep CSRF protection enabled by default.  
In this file, update the `securityFilterChain` configuration so it no longer calls `csrf.disable()`.

Single best minimal change (without altering overall auth logic):  
- In `backend/src/main/java/com/lakucha/config/SecurityConfig.java`, replace:
  - `.csrf(csrf -> csrf.disable())`
  with:
  - `.csrf(csrf -> {})`
This preserves explicit CSRF configuration in the DSL while keeping Spring Security defaults (enabled). No new methods or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
